### PR TITLE
feat: add basic meta/footer/header with static data

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -93,7 +93,10 @@ const ASTRO_OVERRIDE = {
   parserOptions: {
     extraFileExtensions: [".astro"],
   },
-  rules: BASE_RULES,
+  rules: {
+    ...BASE_RULES,
+    "react/no-unknown-property": ["error", { ignore: ["class"] }],
+  },
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -95,5 +95,5 @@
   "engines": {
     "node": ">=16"
   },
-  "packageManager": "pnpm@7.11.0"
+  "packageManager": "pnpm@7.14.0"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build --experimental-integrations",
-    "preview": "astro preview",
+    "preview": "astro preview --experimental-integrations",
     "astro": "astro",
     "format": "prettier --write --plugin-search-dir=. .",
     "lint": "astro check && eslint . --cache --fix --ext .js,.ts,.astro",

--- a/src/components/FaIcon.tsx
+++ b/src/components/FaIcon.tsx
@@ -1,0 +1,15 @@
+import type { IconDefinition } from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface Props {
+  icon: IconDefinition;
+}
+
+/**
+ * Creates a standard-sized font awesome icon
+ */
+const FaIcon = ({ icon }: Props) => (
+  <FontAwesomeIcon width="1em" height="1em" icon={icon} />
+);
+
+export default FaIcon;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,46 @@
+import { styled } from "@stitches/react";
+import Link from "components/Link";
+
+// Switches to two rows for mobile
+const Navigation = styled("nav", {
+  flexDirection: "column",
+  "@bp1": {
+    flexDirection: "row",
+  },
+});
+
+// Wraps so it can collapse better on mobile
+const FlexList = styled("ul", {
+  display: "flex",
+  flexWrap: "wrap",
+});
+
+/**
+ * Creates the site footer component - shows version data + copyright
+ */
+const Footer = () => {
+  const { data: version } = { data: "placeholderVersion" };
+  const { data: footerLinks } = {
+    data: [{ title: "placeholderLink", url: "placeholderUrl" }],
+  };
+  const listedLinkElements = footerLinks?.map((link) => (
+    <li key={link.url}>
+      <Link {...link} isExternal={link.url?.startsWith("http")} />
+    </li>
+  ));
+  return (
+    <section className="container">
+      <footer>
+        <Navigation>
+          <FlexList>
+            <li>© {new Date().getFullYear()} Dylan Gattey</li>
+            <li>{version}</li>
+          </FlexList>
+          <FlexList>{listedLinkElements}</FlexList>
+        </Navigation>
+      </footer>
+    </section>
+  );
+};
+
+export default Footer;

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,124 @@
+import FaIcon from "components/FaIcon";
+import { faGithubAlt } from "@fortawesome/free-brands-svg-icons/faGithubAlt";
+import { faInstagram } from "@fortawesome/free-brands-svg-icons/faInstagram";
+import { faLinkedinIn } from "@fortawesome/free-brands-svg-icons/faLinkedinIn";
+import { faSpotify } from "@fortawesome/free-brands-svg-icons/faSpotify";
+import { faStrava } from "@fortawesome/free-brands-svg-icons/faStrava";
+import { faPaperPlane } from "@fortawesome/free-solid-svg-icons/faPaperPlane";
+import { faQuestion } from "@fortawesome/free-solid-svg-icons/faQuestion";
+import { styled } from "@stitches/react";
+
+/**
+ * Renders as a certain type of layout.
+ * 1. 'text' renders just plain text
+ * 2. 'icon' renders the icon with a tooltip
+ * 4. 'plainIcon' renders just the icon, but without a tooltip
+ * 3. 'plainIconAndText' renders the icon without a tooltip, next to text
+ * 5. 'empty' renders a link without content - usually coupled with spanning the parent
+ */
+type Layout = "text" | "icon" | "plainIcon" | "plainIconAndText" | "empty";
+
+type Props = Pick<React.ComponentProps<"div">, "className" | "children"> & {
+  /**
+   * Defaults to `text` when there's no icon, or `icon` when one is specified
+   */
+  layout?: Layout;
+
+  /**
+   * Defaults to false, but can be set to true to add target="_blank" and
+   * rel="noreferrer"
+   */
+  isExternal?: boolean;
+
+  title?: string;
+  url: string;
+  icon?: string;
+};
+
+// Used a few times, required layout
+type SubProps = {
+  layout: Layout;
+  title?: string | undefined;
+  icon?: string | undefined;
+};
+
+/**
+ * All built in mappings for icon name to element
+ */
+const BUILT_IN_ICONS: Record<string, JSX.Element> = {
+  strava: <FaIcon icon={faStrava} />,
+  spotify: <FaIcon icon={faSpotify} />,
+  github: <FaIcon icon={faGithubAlt} />,
+  linkedin: <FaIcon icon={faLinkedinIn} />,
+  instagram: <FaIcon icon={faInstagram} />,
+  about: <FaIcon icon={faQuestion} />,
+  email: <FaIcon icon={faPaperPlane} />,
+};
+
+// Allows us to use with the right props
+const StyledLink = styled("a");
+
+// Used for setting internal HTML for a non-built in icon
+const NonBuiltInIcon = styled("span");
+
+// When we render the title with an icon, we need some spacing
+const WithIconTitle = styled("span", {
+  marginLeft: "0.25rem",
+});
+
+/**
+ * If there's an icon, returns it, either built in or not, along with its title if
+ * the layout calls for it.
+ */
+const createIconElement = ({ icon, title, layout }: SubProps) =>
+  icon && !["empty", "text"].includes(layout) ? (
+    <>
+      {BUILT_IN_ICONS[icon] ?? (
+        <NonBuiltInIcon dangerouslySetInnerHTML={{ __html: icon }} />
+      )}
+      {layout === "plainIconAndText" && <WithIconTitle>{title}</WithIconTitle>}
+    </>
+  ) : null;
+
+/**
+ * Creates the tooltip contents if the layout calls for it
+ */
+const tooltip = ({ title, layout }: SubProps) =>
+  layout === "icon" ? title ?? undefined : undefined;
+
+/**
+ * Renders a link component from Contentful. Sometimes the icons are
+ * just specifications for what to render using an icon library,
+ * sometimes they're actual SVG html. Renders according to the layout,
+ * or defaults to `icon` if one is specified, otherwise `text`. Returns
+ * null if no link at all.
+ */
+const Link = ({
+  title,
+  url,
+  icon,
+  layout: rawLayout,
+  className,
+  children,
+  isExternal,
+}: Props) => {
+  const layout = rawLayout ?? (icon && !children ? "icon" : "text");
+  if (!url) {
+    return null;
+  }
+
+  // If there's a custom or built in icon, create a link around it
+  const iconElement = createIconElement({ title, icon, layout });
+  return (
+    <StyledLink
+      className={className}
+      href={url}
+      data-tooltip={tooltip({ title, icon, layout })}
+      {...(isExternal ? { target: "_blank", rel: "noreferrer" } : {})}
+    >
+      {layout === "empty" ? null : children ?? iconElement ?? title}
+    </StyledLink>
+  );
+};
+
+export default Link;

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,0 +1,172 @@
+import AppStyle from "components/AppStyle";
+
+interface Props {
+  /**
+   * Tab/window title that shows in a browser
+   */
+  title?: string;
+
+  /**
+   * Description shown to Google/others
+   */
+  description?: string;
+
+  /**
+   * Current page URL, from serverside props
+   */
+  pageUrl: string;
+}
+
+/**
+ * Maps from graph item names like "url" for "og:url"/"twitter:url" to their
+ * content, like "https://example" or "undefined"
+ */
+type Graph = Record<string, string | undefined>;
+
+const MAX_DESC_LENGTH = 300;
+const APP_THEME_COLOR = "#16ac7e";
+const APP_BACKGROUND_COLOR = "#ffffff";
+const SITE_NAME = "Dylan Gattey";
+const OG_IMAGE_URL = "https://og.dylangattey.com";
+const GRAPH_PREFIXES = ["og", "twitter"] as const;
+
+/**
+ * Helps reduce duplication for creation of link elements
+ */
+const linkFromSize = (size: string, fileType: string, rel = "icon") => (
+  <link
+    key={`${size}${fileType}`}
+    rel={rel}
+    href={`/icons/${fileType}-${size}.png`}
+    sizes={`${size}x${size}`}
+  />
+);
+
+/**
+ * Helps reduce duplication for creation of meta elements
+ */
+const metaFromSize = (size: string, fileType: string, name: string) => (
+  <meta
+    key={`${size}${fileType}`}
+    name={name}
+    content={`/icons/${fileType}-${size}.png`}
+  />
+);
+
+/**
+ * Organizes and maps icon file sizes/names to their created elements - keep this
+ * up to date with everything in public/icons/*.png
+ */
+const ICONS = {
+  generic: {
+    variants: [32, 144, 192, 228],
+    element: (size: string) => linkFromSize(size, "favicon"),
+  },
+  android: {
+    variants: [96, 128, 144, 192, 196, 512],
+    element: (size: string) => linkFromSize(size, "prerounded"),
+  },
+  ios: {
+    variants: [57, 76, 120, 152, 167, 180, 512, 1024],
+    element: (size: string) =>
+      linkFromSize(size, "touch-icon", "apple-touch-icon"),
+  },
+  windows: {
+    variants: [144],
+    element: (size: string) =>
+      metaFromSize(size, "favicon", "msapplication-TileImage"),
+  },
+  thumbnail: {
+    variants: [152],
+    element: (size: string) => metaFromSize(size, "touch-icon", "thumbnail"),
+  },
+  mask: {
+    variants: ["safari-pinned-tab.svg"],
+    element: (name: string) => (
+      <link
+        key={`${name}mask`}
+        rel="mask-icon"
+        href={`/icons/${name}`}
+        color={APP_THEME_COLOR}
+      />
+    ),
+  },
+} as const;
+
+/**
+ * Small helper to create og: and twitter: elements for keys + content
+ */
+const graphMetaItems = (graph: Graph) =>
+  Object.entries(graph).map(([name, content]) =>
+    GRAPH_PREFIXES.map((prefix) =>
+      content ? (
+        <meta
+          key={`${prefix}:${name}`}
+          property={`${prefix}:${name}`}
+          content={content}
+        />
+      ) : undefined
+    )
+  );
+
+/**
+ * Populates the `<head>` of a given page from the title/description here
+ */
+const Meta = ({ title, description, pageUrl }: Props) => {
+  const truncatedDescription =
+    description && description.length > MAX_DESC_LENGTH
+      ? `${description.slice(0, MAX_DESC_LENGTH)}...`
+      : description;
+  const resolvedTitle = title ? `${title} | ${SITE_NAME}` : SITE_NAME;
+
+  // Construct url with encoded periods too to not confuse the parser
+  const imageTitle = title
+    ? encodeURIComponent(title).replace(/\./g, "%2E")
+    : "%20";
+
+  return (
+    <head>
+      <meta charSet="UTF-8" />
+      <meta name="viewport" content="width=device-width" />
+      <meta key="og:site_name" property="og:site_name" content={SITE_NAME} />
+      <meta key="og:locale" property="og:locale" content="en_US" />
+      <meta key="og:type" property="og:type" content="website" />
+      <meta
+        key="twitter:card"
+        name="twitter:card"
+        content="summary_large_image"
+      />
+      <title key="title">{resolvedTitle}</title>
+      {truncatedDescription && (
+        <meta
+          key="description"
+          name="description"
+          content={truncatedDescription}
+        />
+      )}
+      {graphMetaItems({
+        title: title ?? SITE_NAME,
+        description: truncatedDescription,
+        url: pageUrl,
+        image: `${OG_IMAGE_URL}/${imageTitle}?md=true`,
+      })}
+      <link key="favicon" rel="icon" href="/favicon.ico" />
+      <meta
+        key="theme-color"
+        name="theme-color"
+        content="var(--background-color)"
+      />
+      <meta
+        key="msapplication-TileColor"
+        name="msapplication-TileColor"
+        content={APP_BACKGROUND_COLOR}
+      />
+      {Object.values(ICONS).flatMap(({ variants, element }) =>
+        variants.map((variant) => element(String(variant)))
+      )}
+      <AppStyle />
+    </head>
+  );
+};
+
+export default Meta;

--- a/src/components/ScrollIndicatorContext.tsx
+++ b/src/components/ScrollIndicatorContext.tsx
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+/**
+ * Indicates whether the scroll indicator should show globally across
+ * the app. Based on user scroll position.
+ */
+const ScrollIndicatorContext = createContext(false);
+
+export default ScrollIndicatorContext;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -16,9 +16,7 @@ const StickyContainer = styled("section", {
   "pointer-events": "none",
 });
 
-const LogoHolder = styled("li", {
-  padding: 0,
-});
+const LogoHolder = styled("li");
 
 /**
  * Creates the site header component. It's a bar that spans across the

--- a/src/components/header/Logo.tsx
+++ b/src/components/header/Logo.tsx
@@ -1,0 +1,90 @@
+import { useContext } from "react";
+import { styled } from "@stitches/react";
+import ScrollIndicatorContext from "components/ScrollIndicatorContext";
+import Stack from "components/ui/Stack";
+import Link from "components/Link";
+
+interface Props {
+  /**
+   * TODO: @dgattey placeholder for when we have router support maybe
+   */
+  currentPath: string;
+}
+
+/**
+ * Aspect ratio'd 1:1 circle. Big, bold, and squished text for use as
+ * logo. Has background on scroll + scales down a bit.
+ */
+const LogoText = styled("article", {
+  "--padding": "1rem",
+  "--margin": "0.5rem",
+
+  "@bp1": {
+    "--margin": "1rem",
+  },
+
+  fontSize: "2.5rem",
+  fontVariationSettings: '"wght" 800, "wdth" 120',
+  letterSpacing: "-0.12em",
+
+  overflow: "visible",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: "50%",
+  verticalAlign: "middle",
+  lineHeight: 1,
+  margin: "var(--margin) -0.5rem",
+  padding: "var(--padding)",
+  pointerEvents: "auto",
+  transformOrigin: "top left",
+  transition:
+    "box-shadow var(--transition), transform var(--transition), background-color var(--transition), border-color var(--transition)",
+  willChange: "transform",
+  color: "rgb(22, 172, 126)",
+  border: "2px solid transparent",
+  zIndex: "1",
+
+  background: "var(--background-color)",
+  boxShadow: "none",
+
+  "&:before": {
+    content: "",
+    float: "left",
+    width: "auto",
+    paddingBottom: "100%",
+  },
+
+  variants: {
+    isScrolled: {
+      true: {
+        border: "2px solid var(--card-border-color)",
+        transform: "scale(0.75)",
+      },
+    },
+  },
+});
+
+/**
+ * Logo + scroll to top button, with certain changes that happen on
+ * scroll.
+ */
+const Logo = ({ currentPath }: Props) => {
+  const isScrolled = useContext(ScrollIndicatorContext);
+  const linkedLogoText =
+    currentPath === "/" ? (
+      "dg."
+    ) : (
+      <Link url="/" title="Homepage">
+        dg.
+      </Link>
+    );
+  return (
+    <Stack css={{ alignItems: "flex-start" }}>
+      <LogoText isScrolled={isScrolled}>{linkedLogoText}</LogoText>
+      {/* <SpacedScrollIndicator $isScrolled={isScrolled} />  TODO: @dgattey do this one */}
+    </Stack>
+  );
+};
+
+export default Logo;

--- a/src/components/ui/Box.tsx
+++ b/src/components/ui/Box.tsx
@@ -1,0 +1,10 @@
+import { styled } from "@stitches/react";
+
+/**
+ * Stacks content, usually vertically.
+ */
+const Box = styled("div", {
+  display: "flex",
+});
+
+export default Box;

--- a/src/components/ui/Stack.tsx
+++ b/src/components/ui/Stack.tsx
@@ -1,0 +1,11 @@
+import { styled } from "@stitches/react";
+import Box from "components/ui/Box";
+
+/**
+ * Stacks content - has a few properities built in as props for convenience
+ */
+const Stack = styled(Box, {
+  flexDirection: "column",
+});
+
+export default Stack;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,23 +1,18 @@
 ---
-import AppStyle from "components/AppStyle";
+import Meta from "components/Meta";
+import PageLayout from "layouts/PageLayout";
 
 export interface Props {
-  title: string;
+  title?: string;
+  pageUrl: string;
+  description?: string;
 }
-
-const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>{title}</title>
-    <AppStyle />
-  </head>
+  <Meta {...Astro.props} />
   <body>
-    <slot />
+    <PageLayout><slot /></PageLayout>
   </body>
 </html>

--- a/src/layouts/PageLayout.tsx
+++ b/src/layouts/PageLayout.tsx
@@ -1,0 +1,29 @@
+import Footer from "components/Footer";
+import Header from "components/header/Header";
+import ScrollIndicatorContext from "components/ScrollIndicatorContext";
+import { useRef } from "react";
+
+/**
+ * We have props that dictate a fallback for SWRConfig, plus children
+ */
+type Props = Pick<React.ComponentProps<"div">, "children">;
+
+/**
+ * Basic page layout for every page. Has a sticky, contained header above
+ * the main (contained) content, with a (contained) footer below. No wrapper
+ * around all items to save on divs. Ensures color scheme is applied.
+ */
+const PageLayout = ({ children }: Props) => {
+  const headerSizingRef = useRef<HTMLDivElement>(null);
+  return (
+    <ScrollIndicatorContext.Provider value={false}>
+      <Header headerRef={headerSizingRef} />
+      <section className="container">
+        <main>{children}</main>
+      </section>
+      <Footer />
+    </ScrollIndicatorContext.Provider>
+  );
+};
+
+export default PageLayout;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
-import Header from "components/Header";
-import Layout from "../layouts/Layout.astro";
+import Layout from "layouts/Layout.astro";
 ---
 
-<Layout title="dg.">
-  <Header>hi</Header>
-</Layout>
+<Layout
+  pageUrl="https://beta.dylangattey.com"
+  description="Engineer. Problem solver.">hi this is placeholder content</Layout
+>

--- a/stitches.config.ts
+++ b/stitches.config.ts
@@ -1,3 +1,19 @@
 import { createStitches } from "@stitches/react";
 
-export const { getCssText } = createStitches();
+export const { getCssText } = createStitches({
+  theme: {
+    space: {
+      1: "4px",
+      2: "8px",
+      3: "12px",
+      4: "16px",
+      5: "20px",
+      6: "24px",
+      7: "28px",
+      8: "32px",
+    },
+  },
+  media: {
+    bp1: "(min-width: 768px)",
+  },
+});


### PR DESCRIPTION
# Description of changes

Starts actually adding content, mostly just the meta/header/footer/index page components for now, with placeholder data